### PR TITLE
add specific package version reference to mitigate missing blazor fra…

### DIFF
--- a/src/tara-tool.csproj
+++ b/src/tara-tool.csproj
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App.Internal.Assets" Version="10.0.5" />
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.14.0" />
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.14.0" />
   </ItemGroup>


### PR DESCRIPTION
This PR solves a conflict of the docker image unable to load any javascript content and cause the application to freeze.

After the first package creation i investigated an issue causing the application to freeze. The app was completely unstyled and non-interactive when running inside Docker because `blazor.web.js` (the file that boots up the Blazor framework) was returning 404.

The root cause: a Microsoft-internal NuGet package (Microsoft.AspNetCore.App.Internal.Assets) that provides this file behaves differently depending on how it is referenced.

By adding an explicit reference to this package in the project file, NuGet downloads the full package including the missing file during the docker image creation process.

 