### PR TITLE
Feature/support arm64 docker

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,6 +18,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -31,6 +37,9 @@ jobs:
           context: .
           push: true
           tags: ${{ env.IMAGE }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   deploy:
     runs-on: self-hosted

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -40,23 +40,3 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-  deploy:
-    runs-on: self-hosted
-    needs: build-and-push
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Copy compose file to deployment directory
-        run: |
-          mkdir -p /srv/thiara/data
-          cp docker-compose.yml /srv/thiara/docker-compose.yml
-
-      - name: Pull latest image and restart
-        env:
-          TARA_TOOL_IMAGE: ${{ env.IMAGE }}
-        run: |
-          docker compose -f /srv/thiara/docker-compose.yml pull
-          docker compose -f /srv/thiara/docker-compose.yml up -d

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, 'sprint/*' ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, 'sprint/*' ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
This PR includes the following changes:
- New Docker image build process for arm64 and amd64. If an image is pulled docker decides which image architecture to pull based on the host system.
- Removed no longer necessary self-hosted deployment process
- Removed `sprint` branches from CI 