### PR TITLE
Feature/case insensitive mail

### DIFF
--- a/src/Components/Account/Pages/ConfirmEmail.razor
+++ b/src/Components/Account/Pages/ConfirmEmail.razor
@@ -1,9 +1,8 @@
-﻿@page "/Account/ConfirmEmail"
+@page "/Account/ConfirmEmail"
 
 @using System.Text
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
-@using tara_tool.Data
 @using tara_tool.Data.Tables
 
 @inject UserManager<ApplicationUser> UserManager

--- a/src/Components/Account/Pages/ConfirmEmailChange.razor
+++ b/src/Components/Account/Pages/ConfirmEmailChange.razor
@@ -1,9 +1,8 @@
-﻿@page "/Account/ConfirmEmailChange"
+@page "/Account/ConfirmEmailChange"
 
 @using System.Text
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
-@using tara_tool.Data
 @using tara_tool.Data.Tables
 
 @inject UserManager<ApplicationUser> UserManager

--- a/src/Components/Account/Pages/Login.razor
+++ b/src/Components/Account/Pages/Login.razor
@@ -94,7 +94,8 @@
 
         // This doesn't count login failures towards account lockout
         // To enable password failures to trigger account lockout, set lockoutOnFailure: true
-        result = await SignInManager.PasswordSignInAsync(Input.Email, Input.Password, Input.RememberMe, lockoutOnFailure: true);
+        // Calling ToUpper, eventhough the name should be normalized later on
+        result = await SignInManager.PasswordSignInAsync(Input.Email.ToUpper(), Input.Password, Input.RememberMe, lockoutOnFailure: true);
 
         if (result.Succeeded)
         {

--- a/src/Components/Account/Pages/Register.razor
+++ b/src/Components/Account/Pages/Register.razor
@@ -109,9 +109,9 @@
             return;
         }
 
-        await UserStore.SetUserNameAsync(user, Input.Email, CancellationToken.None);
+        await UserStore.SetUserNameAsync(user, Input.Email.ToUpper(), CancellationToken.None);
         IUserEmailStore<ApplicationUser>? emailStore = GetEmailStore();
-        await emailStore.SetEmailAsync(user, Input.Email, CancellationToken.None);
+        await emailStore.SetEmailAsync(user, Input.Email.ToUpper(), CancellationToken.None);
         IdentityResult? result = await UserManager.CreateAsync(user, Input.Password);
         user.Organization = Input.Organization;
         await UserManager.UpdateAsync(user);

--- a/src/Components/Account/Pages/Register.razor
+++ b/src/Components/Account/Pages/Register.razor
@@ -109,9 +109,9 @@
             return;
         }
 
-        await UserStore.SetUserNameAsync(user, Input.Email.ToUpper(), CancellationToken.None);
+        await UserStore.SetUserNameAsync(user, Input.Email, CancellationToken.None);
         IUserEmailStore<ApplicationUser>? emailStore = GetEmailStore();
-        await emailStore.SetEmailAsync(user, Input.Email.ToUpper(), CancellationToken.None);
+        await emailStore.SetEmailAsync(user, Input.Email, CancellationToken.None);
         IdentityResult? result = await UserManager.CreateAsync(user, Input.Password);
         user.Organization = Input.Organization;
         await UserManager.UpdateAsync(user);

--- a/src/Data/Services/ApplicationUserService.cs
+++ b/src/Data/Services/ApplicationUserService.cs
@@ -1,5 +1,4 @@
 using Microsoft.EntityFrameworkCore;
-using System.Security.Cryptography;
 using tara_tool.Data;
 using tara_tool.Data.Tables;
 
@@ -30,8 +29,9 @@ public class ApplicationUserService(IDbContextFactory<ApplicationDbContext> cont
 
     public async Task<bool> CheckEmailDuplicate(string email)
     {
+        string normalized = email.ToUpper();
         using ApplicationDbContext context = await contextFactory.CreateDbContextAsync();
-        return await context.ApplicationUsers.AnyAsync(p => p.Email == email);
+        return await context.ApplicationUsers.AnyAsync(p => p.NormalizedEmail == normalized);
     }
 
     public async Task<bool> CheckNameOfUserDuplicate(string username)

--- a/src/Data/Services/AssetService.cs
+++ b/src/Data/Services/AssetService.cs
@@ -123,7 +123,7 @@ public class AssetService(
             }
 
             int total = await Asset.CountAsync();
-            List<Asset> items = await request.ApplySorting(Asset)
+            List<Asset> items = await request.ApplySorting(Asset.OrderBy(a => a.Id))
                                     .Skip(request.StartIndex)
                                     .Take(request.Count ?? 20)
                                     .ToListAsync(request.CancellationToken);

--- a/src/Data/Services/DamageScenarioService.cs
+++ b/src/Data/Services/DamageScenarioService.cs
@@ -145,7 +145,7 @@ public class DamageScenarioService(
                 damageScenario = filter(damageScenario);
 
             int total = await damageScenario.CountAsync();
-            List<DamageScenario> items = await request.ApplySorting(damageScenario)
+            List<DamageScenario> items = await request.ApplySorting(damageScenario.OrderBy(ds => ds.Id))
                                              .Skip(request.StartIndex)
                                              .Take(request.Count ?? 20)
                                              .ToListAsync(request.CancellationToken);

--- a/src/Data/Services/ItemsService.cs
+++ b/src/Data/Services/ItemsService.cs
@@ -198,7 +198,7 @@ public class ItemDefinitionService(
             }
 
             int total = await itemDefinitions.CountAsync();
-            List<ItemDefinition> items = await request.ApplySorting(itemDefinitions)
+            List<ItemDefinition> items = await request.ApplySorting(itemDefinitions.OrderBy(i => i.ItemNumber))
                                              .Skip(request.StartIndex)
                                              .Take(request.Count ?? 20)
                                              .ToListAsync(request.CancellationToken);

--- a/src/Data/Services/PendingRegistrationService.cs
+++ b/src/Data/Services/PendingRegistrationService.cs
@@ -8,7 +8,7 @@ public class PendingRegistrationService(
 {
     public async Task<string?> Create(string email)
     {
-        email = email.ToLower();
+        email = email.ToUpper();
         string id = RandomNumberGenerator.GetHexString(64, true);
 
         PendingRegistration pendingRegistration = new(){Email=email, Id=id};
@@ -21,7 +21,7 @@ public class PendingRegistrationService(
 
     private async Task<bool> Save(PendingRegistration entityToSave)
     {
-        entityToSave.Email = entityToSave.Email.ToLower();
+        entityToSave.Email = entityToSave.Email.ToUpper();
         using ApplicationDbContext context = await contextFactory.CreateDbContextAsync();
 
         try
@@ -39,7 +39,7 @@ public class PendingRegistrationService(
 
     public async Task<bool> Check(string email, string id, bool firstUser)
     {
-        email = email.ToLower();
+        email = email.ToUpper();
         using ApplicationDbContext context = await contextFactory.CreateDbContextAsync();
 
         if (firstUser)

--- a/src/Data/Services/PendingRegistrationService.cs
+++ b/src/Data/Services/PendingRegistrationService.cs
@@ -8,6 +8,7 @@ public class PendingRegistrationService(
 {
     public async Task<string?> Create(string email)
     {
+        email = email.ToLower();
         string id = RandomNumberGenerator.GetHexString(64, true);
 
         PendingRegistration pendingRegistration = new(){Email=email, Id=id};
@@ -20,6 +21,7 @@ public class PendingRegistrationService(
 
     private async Task<bool> Save(PendingRegistration entityToSave)
     {
+        entityToSave.Email = entityToSave.Email.ToLower();
         using ApplicationDbContext context = await contextFactory.CreateDbContextAsync();
 
         try
@@ -37,6 +39,7 @@ public class PendingRegistrationService(
 
     public async Task<bool> Check(string email, string id, bool firstUser)
     {
+        email = email.ToLower();
         using ApplicationDbContext context = await contextFactory.CreateDbContextAsync();
 
         if (firstUser)

--- a/src/Data/Services/ProjectService.cs
+++ b/src/Data/Services/ProjectService.cs
@@ -615,9 +615,10 @@ public class ProjectService(
         using ApplicationDbContext context =
             await _contextFactory.CreateDbContextAsync();
 
+        string normalizedEmail = email.ToUpper();
         ApplicationUser? targetUser =
-            await context.ApplicationUsers.FirstOrDefaultAsync(u => u.Email ==
-                                                                    email);
+            await context.ApplicationUsers.FirstOrDefaultAsync(u => u.NormalizedEmail ==
+                                                                    normalizedEmail);
         if (targetUser == null)
             return "User not found.";
 

--- a/src/Data/Services/ProjectService.cs
+++ b/src/Data/Services/ProjectService.cs
@@ -381,7 +381,7 @@ public class ProjectService(
             }
 
             int total = await projects.CountAsync();
-            List<Project> items = await request.ApplySorting(projects)
+            List<Project> items = await request.ApplySorting(projects.OrderBy(p => p.Id))
                                       .Skip(request.StartIndex)
                                       .Take(request.Count ?? 20)
                                       .ToListAsync(request.CancellationToken);

--- a/src/Data/Services/ThreatScenarioService.cs
+++ b/src/Data/Services/ThreatScenarioService.cs
@@ -338,7 +338,7 @@ public class ThreatScenarioService(
                       projectId);
 
             int total = await query.CountAsync(request.CancellationToken);
-            List<ThreatScenario> items = await request.ApplySorting(query)
+            List<ThreatScenario> items = await request.ApplySorting(query.OrderBy(ts => ts.Id))
                                              .Skip(request.StartIndex)
                                              .Take(request.Count ?? 20)
                                              .ToListAsync(request.CancellationToken);


### PR DESCRIPTION
- Fixed: Fixed warnings at runtime `warn: Microsoft.EntityFrameworkCore.Query[10102]`
- Added: Made the E-Mails case insensitive 
- Used: Used `.ToUpper()`, to comply with the normalization used in the login manager and throughout EfCore -> `SigninManager` and also the `NormalizedEmail` field inside the `ApplicationUser`
- See: #207