### PR TITLE
add popup modal to require selecting a security goal before a damage scenario can be created

### DIFF
--- a/src/Components/Dialogs/CreateDamageScenarioDialog.razor
+++ b/src/Components/Dialogs/CreateDamageScenarioDialog.razor
@@ -1,0 +1,41 @@
+@using Microsoft.FluentUI.AspNetCore.Components
+@implements IDialogContentComponent<CreateDamageScenarioDialog.Goals>
+@rendermode InteractiveServer
+
+<FluentDialogHeader ShowDismiss="true">
+    <FluentStack VerticalAlignment="VerticalAlignment.Center">
+        <FluentIcon Value="@(new Icons.Regular.Size28.ShieldCheckmark())" />
+        <h3>New Damage Scenario</h3>
+    </FluentStack>
+</FluentDialogHeader>
+<FluentDialogBody>
+    <p>Select at least one affected security goal:</p>
+    <FluentStack>
+        <FluentCheckbox @bind-Value="Content.Confidentiality">Confidentiality</FluentCheckbox>
+        <FluentCheckbox @bind-Value="Content.Integrity">Integrity</FluentCheckbox>
+        <FluentCheckbox @bind-Value="Content.Availability">Availability</FluentCheckbox>
+    </FluentStack>
+</FluentDialogBody>
+<FluentDialogFooter>
+    <FluentButton Appearance="Appearance.Accent" Disabled="@(!IsValid)"
+                  OnClick="@(() => { if (Dialog is not null) Dialog.CloseAsync(Content); })">
+        Create
+    </FluentButton>
+</FluentDialogFooter>
+
+@code {
+    [Parameter]
+    public required Goals Content { get; set; }
+
+    [CascadingParameter]
+    public FluentDialog? Dialog { get; set; }
+
+    private bool IsValid => Content.Confidentiality || Content.Integrity || Content.Availability;
+
+    public class Goals
+    {
+        public bool Confidentiality { get; set; }
+        public bool Integrity { get; set; }
+        public bool Availability { get; set; }
+    }
+}

--- a/src/Components/Pages/Assets/AssetPage.razor
+++ b/src/Components/Pages/Assets/AssetPage.razor
@@ -154,7 +154,7 @@
         DialogResult result = await dialog.Result;
         if (result is { Cancelled: true } or { Data: null }) return;
 
-        var goals = (CreateDamageScenarioDialog.Goals)result.Data;
+        CreateDamageScenarioDialog.Goals goals = (CreateDamageScenarioDialog.Goals)result.Data;
         DamageScenario? ds = await DamageScenarioService.CreateNew(
             IdAsset, goals.Confidentiality, goals.Integrity, goals.Availability);
         if (ds is not null)

--- a/src/Components/Pages/Assets/AssetPage.razor
+++ b/src/Components/Pages/Assets/AssetPage.razor
@@ -75,9 +75,11 @@
                              HorizontalAlignment="HorizontalAlignment.SpaceBetween">
                     <span><strong>Damage Scenarios</strong></span>
                     <FluentSpacer />
-                    <FluentButton IconStart=@(new Icons.Regular.Size20.Add()) OnClick="CreateDamageScenario">
-                        New Damage Scenario
-                    </FluentButton>
+                    <div @onclick:stopPropagation="true">
+                        <FluentButton IconStart=@(new Icons.Regular.Size20.Add()) OnClick="CreateDamageScenario">
+                            New Damage Scenario
+                        </FluentButton>
+                    </div>
                 </FluentStack>
             </HeadingTemplate>
             <ChildContent>
@@ -147,7 +149,14 @@
 
     private async Task CreateDamageScenario()
     {
-        DamageScenario? ds = await DamageScenarioService.CreateNew(IdAsset);
+        IDialogReference dialog = await DialogService.ShowDialogAsync<CreateDamageScenarioDialog>(
+            new CreateDamageScenarioDialog.Goals(), new DialogParameters());
+        DialogResult result = await dialog.Result;
+        if (result is { Cancelled: true } or { Data: null }) return;
+
+        var goals = (CreateDamageScenarioDialog.Goals)result.Data;
+        DamageScenario? ds = await DamageScenarioService.CreateNew(
+            IdAsset, goals.Confidentiality, goals.Integrity, goals.Availability);
         if (ds is not null)
         {
             NavigationManager.NavigateTo($"/DamageScenario/{ds.Id}");

--- a/src/Components/Pages/DamageScenarios/DamageScenarioPage.razor
+++ b/src/Components/Pages/DamageScenarios/DamageScenarioPage.razor
@@ -46,19 +46,27 @@
 
         <FluentAccordion Class="fullwidth">
             <FluentAccordionItem Expanded=true Heading="Affected Security Goals">
-                <FluentStack>
-                    <FluentCheckbox @bind-Value=@damageScenario.ConfidentialityAffected
-                                    @bind-Value:after=@genericAutosave.ScheduleAutoSave>
-                        Confidentiality
-                    </FluentCheckbox>
-                    <FluentCheckbox @bind-Value=@damageScenario.IntegrityAffected
-                                    @bind-Value:after=@genericAutosave.ScheduleAutoSave>
-                        Integrity
-                    </FluentCheckbox>
-                    <FluentCheckbox @bind-Value=@damageScenario.AvailabilityAffected
-                                    @bind-Value:after=@genericAutosave.ScheduleAutoSave>
-                        Availability
-                    </FluentCheckbox>
+                <FluentStack Orientation="Orientation.Vertical" VerticalGap=4>
+                    <FluentStack>
+                        <FluentCheckbox Value="@damageScenario.ConfidentialityAffected"
+                                        ValueChanged="@(v => SetSecurityGoal(val => damageScenario!.ConfidentialityAffected = val, v))">
+                            Confidentiality
+                        </FluentCheckbox>
+                        <FluentCheckbox Value="@damageScenario.IntegrityAffected"
+                                        ValueChanged="@(v => SetSecurityGoal(val => damageScenario!.IntegrityAffected = val, v))">
+                            Integrity
+                        </FluentCheckbox>
+                        <FluentCheckbox Value="@damageScenario.AvailabilityAffected"
+                                        ValueChanged="@(v => SetSecurityGoal(val => damageScenario!.AvailabilityAffected = val, v))">
+                            Availability
+                        </FluentCheckbox>
+                    </FluentStack>
+                    @if (securityGoalError)
+                    {
+                        <FluentMessageBar Intent="MessageIntent.Error" AllowDismiss="false">
+                            At least one security goal must remain selected.
+                        </FluentMessageBar>
+                    }
                 </FluentStack>
             </FluentAccordionItem>
             <FluentAccordionItem Expanded=true Heading="Impact Rating">
@@ -121,6 +129,21 @@
         long? assetId = damageScenario?.Asset?.Id;
         if (damageScenario is not null) await DamageScenarioService.Delete(damageScenario);
         if (assetId is not null) NavigationManager.NavigateTo($"/Asset/{assetId}");
+    }
+
+    private bool securityGoalError = false;
+
+    private void SetSecurityGoal(Action<bool> setter, bool newValue)
+    {
+        setter(newValue);
+        if (!damageScenario!.ConfidentialityAffected && !damageScenario.IntegrityAffected && !damageScenario.AvailabilityAffected)
+        {
+            setter(!newValue); 
+            securityGoalError = true;
+            return;
+        }
+        securityGoalError = false;
+        genericAutosave.ScheduleAutoSave();
     }
 
     private async Task CreateThreatScenario()

--- a/src/Data/Services/DamageScenarioService.cs
+++ b/src/Data/Services/DamageScenarioService.cs
@@ -13,7 +13,7 @@ public class DamageScenarioService(
     : IDataService<DamageScenario>
 {
 
-    public async Task<DamageScenario?> CreateNew(long idAsset)
+    public async Task<DamageScenario?> CreateNew(long idAsset, bool confidentiality = false, bool integrity = false, bool availability = false)
     {
         using ApplicationDbContext context =
             await contextFactory.CreateDbContextAsync();
@@ -48,7 +48,10 @@ public class DamageScenarioService(
                                       .Max() +
                                   1
                             : 1,
-                Asset = asset
+                Asset = asset,
+                ConfidentialityAffected = confidentiality,
+                IntegrityAffected = integrity,
+                AvailabilityAffected = availability,
             };
 
         damageScenario.Asset.ItemDefinition.Project.DateLastChanged = DateTime.UtcNow;


### PR DESCRIPTION
Changes:
- CreateDamageScenarioDialog.razor => new Modal dialog added
- AssetPage.razor => opens dialog first and passes value to CreateNew instead of creating immediately with all goals unchecked
- DamageScenarioService.cs => CreateNew got three additional boolean vars for the security goals

Issue: https://github.com/tara-tool-thi/tara-tool/issues/185